### PR TITLE
chore: update vue_basic_app to the js-sdk 4.4.0

### DIFF
--- a/vue/vue_basic_app/package-lock.json
+++ b/vue/vue_basic_app/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "vue",
+  "name": "vue_basic_app",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "vue",
+      "name": "vue_basic_app",
       "version": "0.0.0",
       "dependencies": {
         "@anam-ai/js-sdk": "^1.4.0",

--- a/vue/vue_basic_app/package.json
+++ b/vue/vue_basic_app/package.json
@@ -13,7 +13,7 @@
     "format": "prettier --write src/"
   },
   "dependencies": {
-    "@anam-ai/js-sdk": "^1.4.0",
+    "@anam-ai/js-sdk": "^4.4.0",
     "vue": "^3.4.29"
   },
   "devDependencies": {

--- a/vue/vue_basic_app/src/components/PersonaPlayer.vue
+++ b/vue/vue_basic_app/src/components/PersonaPlayer.vue
@@ -21,7 +21,15 @@ const startStreaming = async () => {
       isLoading.value = false
       isStreaming.value = true
     })
-    await anamClient.streamToVideoAndAudioElements('video-id', 'audio-id')
+
+    anamClient.addListener(AnamEvent.AUDIO_STREAM_STARTED, (audioStream: MediaStream) => {
+      const audioElement = document.getElementById('audio-id') as HTMLAudioElement
+      if (audioElement) {
+        audioElement.srcObject = audioStream
+      }
+    })
+
+    await anamClient.streamToVideoElement('video-id')
   } catch (error) {
     console.error('Error starting stream:', error)
     isLoading.value = false

--- a/vue/vue_basic_app/src/components/PersonaPlayer.vue
+++ b/vue/vue_basic_app/src/components/PersonaPlayer.vue
@@ -22,13 +22,6 @@ const startStreaming = async () => {
       isStreaming.value = true
     })
 
-    anamClient.addListener(AnamEvent.AUDIO_STREAM_STARTED, (audioStream: MediaStream) => {
-      const audioElement = document.getElementById('audio-id') as HTMLAudioElement
-      if (audioElement) {
-        audioElement.srcObject = audioStream
-      }
-    })
-
     await anamClient.streamToVideoElement('video-id')
   } catch (error) {
     console.error('Error starting stream:', error)
@@ -51,9 +44,8 @@ onUnmounted(() => {
 <template>
   <div class="flex flex-col items-center">
     <div class="relative bg-slate-700 border-none w-[512px] h-[512px] rounded-xl overflow-hidden">
-      <video v-show="!isLoading && isStreaming" id="video-id" class="object-cover w-full h-full" muted autoplay
+      <video v-show="!isLoading && isStreaming" id="video-id" class="object-cover w-full h-full" autoplay
         playsinline></video>
-      <audio id="audio-id" autoplay></audio>
       <!-- Loading Spinner -->
       <div v-if="isLoading" class="absolute inset-0 flex items-center justify-center">
         <div class="animate-spin rounded-full h-32 w-32 border-t-2 border-b-2 border-white"></div>


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Upgrade vue_basic_app to @anam-ai/js-sdk 4.4.0 and align streaming with the new API. Audio now plays from the video element (no separate audio tag).

- **Dependencies**
  - Bump @anam-ai/js-sdk to ^4.4.0.
  - Set package-lock name to vue_basic_app.

- **Refactors**
  - Replace streamToVideoAndAudioElements with streamToVideoElement.
  - Remove the audio element and its bindings.

<sup>Written for commit 4687ef0ecfce9ab401d3869080d967d749b51548. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



